### PR TITLE
Fix context menus on dial page for Firefox 152+ (replace deprecated tabs.executeScript)

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -46,7 +46,15 @@ app.Messages.Commands = {
 	refreshNode: 9,
 	capturePage: 10,
 	settingsChanged: 100,
-	gridNodesLoaded: 101
+	gridNodesLoaded: 101,
+	menuCreateBookmark: 200,
+	menuCreateFolder: 201,
+	menuEditSettings: 202,
+	menuEditProperties: 203,
+	menuRefreshNode: 204,
+	menuCaptureHere: 205,
+	menuCapturePage: 206,
+	menuDeleteNode: 207
 };
 app.Messages.init = function(){ // Init Messages Listeners
 	browser.runtime.onMessage.addListener(function(request, sender, sendResponse){
@@ -302,18 +310,14 @@ app.ContextMenus.initMenu = function(){ // (Called from app.init) Init context m
 		parentId: "pagemenunew",
 		title: browser.i18n.getMessage("menuNewBookmark"),
 		onclick(info, tab) { 
-			browser.tabs.executeScript(tab.id, {
-				code: "window.dial.createBookmark();"
-			});	
+			browser.tabs.sendMessage(tab.id, { cmd: app.Messages.Commands.menuCreateBookmark });	
 		}
 	});
 	browser.contextMenus.create({
 		parentId: "pagemenunew",
 		title: browser.i18n.getMessage("menuNewFolder"),
 		onclick(info, tab) {
-			browser.tabs.executeScript(tab.id, {
-				code: "window.dial.createFolder();"
-			});	
+			browser.tabs.sendMessage(tab.id, { cmd: app.Messages.Commands.menuCreateFolder });	
 		}
 	});
 	browser.contextMenus.create({	parentId: "pagemenu", type: "separator" });
@@ -321,9 +325,7 @@ app.ContextMenus.initMenu = function(){ // (Called from app.init) Init context m
 		parentId: "pagemenu",
 		title: browser.i18n.getMessage("menuSettings"),
 		onclick(info, tab) {
-			browser.tabs.executeScript(tab.id, {
-				code: "window.dial.editSettings();"
-			});	
+			browser.tabs.sendMessage(tab.id, { cmd: app.Messages.Commands.menuEditSettings });	
 		}
 	});
 	// Create WebExt Link Context menu
@@ -342,18 +344,14 @@ app.ContextMenus.initMenu = function(){ // (Called from app.init) Init context m
 		parentId: "itemmenunew",
 		title: browser.i18n.getMessage("menuNewBookmark"),
 		onclick(info, tab) {
-			browser.tabs.executeScript(tab.id, {
-				code: "window.dial.createBookmark();"
-			});	
+			browser.tabs.sendMessage(tab.id, { cmd: app.Messages.Commands.menuCreateBookmark });	
 		}
 	});
 	browser.contextMenus.create({
 		parentId: "itemmenunew",
 		title: browser.i18n.getMessage("menuNewFolder"),
 		onclick(info, tab) {
-			browser.tabs.executeScript(tab.id, {
-				code: "window.dial.createFolder();"
-			});	
+			browser.tabs.sendMessage(tab.id, { cmd: app.Messages.Commands.menuCreateFolder });	
 		}
 	});
 	browser.contextMenus.create({	parentId: "itemmenu", type: "separator" });
@@ -361,18 +359,14 @@ app.ContextMenus.initMenu = function(){ // (Called from app.init) Init context m
 		parentId: "itemmenu",
 		title: browser.i18n.getMessage("menuProperties"),
 		onclick(info, tab) {
-			browser.tabs.executeScript(tab.id, {
-				code: "window.dial.editProperties(window.dial._selectedItem);"
-			});	
+			browser.tabs.sendMessage(tab.id, { cmd: app.Messages.Commands.menuEditProperties });	
 		}
 	});
 	browser.contextMenus.create({
 		parentId: "itemmenu",
 		title: browser.i18n.getMessage("menuRefreshItem"),
 		onclick(info, tab) {
-			browser.tabs.executeScript(tab.id, {
-				code: "window.dial.refreshNode(window.dial._selectedItem);"
-			});	
+			browser.tabs.sendMessage(tab.id, { cmd: app.Messages.Commands.menuRefreshNode });	
 		}
 	});
 	browser.contextMenus.create({
@@ -380,27 +374,21 @@ app.ContextMenus.initMenu = function(){ // (Called from app.init) Init context m
 		title: browser.i18n.getMessage("menuCaptureHere"),
 		visible: false,
 		onclick(info, tab) {
-			browser.tabs.executeScript(tab.id, {
-				code: "window.dial.captureHere(window.dial._selectedItem);"
-			});	
+			browser.tabs.sendMessage(tab.id, { cmd: app.Messages.Commands.menuCaptureHere });	
 		}
 	});
 	browser.contextMenus.create({
 		parentId: "itemmenu",
 		title: browser.i18n.getMessage("menuCapturePage"),
 		onclick(info, tab) {
-			browser.tabs.executeScript(tab.id, {
-				code: "window.dial.capturePage(window.dial._selectedItem);"
-			});	
+			browser.tabs.sendMessage(tab.id, { cmd: app.Messages.Commands.menuCapturePage });	
 		}
 	});
 	browser.contextMenus.create({
 		parentId: "itemmenu",
 		title: browser.i18n.getMessage("menuDeleteItem"),
 		onclick(info, tab) {
-			browser.tabs.executeScript(tab.id, {
-				code: "window.dial.deleteNode();"
-			});	
+			browser.tabs.sendMessage(tab.id, { cmd: app.Messages.Commands.menuDeleteNode });	
 		}
 	});
 	browser.contextMenus.create({	parentId: "itemmenu", type: "separator" });
@@ -408,9 +396,7 @@ app.ContextMenus.initMenu = function(){ // (Called from app.init) Init context m
 		parentId: "itemmenu",
 		title: browser.i18n.getMessage("menuSettings"),
 		onclick(info, tab) {
-			browser.tabs.executeScript(tab.id, {
-				code: "window.dial.editSettings();"
-			});	
+			browser.tabs.sendMessage(tab.id, { cmd: app.Messages.Commands.menuEditSettings });	
 		}
 	});
 };

--- a/src/js/dial.js
+++ b/src/js/dial.js
@@ -84,7 +84,15 @@ app.Messages.Commands = {
 	refreshNode: 9,
 	capturePage: 10,
 	settingsChanged: 100,
-	gridNodesLoaded: 101
+	gridNodesLoaded: 101,
+	menuCreateBookmark: 200,
+	menuCreateFolder: 201,
+	menuEditSettings: 202,
+	menuEditProperties: 203,
+	menuRefreshNode: 204,
+	menuCaptureHere: 205,
+	menuCapturePage: 206,
+	menuDeleteNode: 207
 };
 app.Messages.init = function(){
 	browser.runtime.onMessage.addListener(function(request, sender, sendResponse){
@@ -94,6 +102,30 @@ app.Messages.init = function(){
 				break;
 			case app.Messages.Commands.gridNodesLoaded:
 				if(dial.skipUpdate!=true) app.Messages.getNode(dial.path, app.GridNodes._changed);
+				break;
+			case app.Messages.Commands.menuCreateBookmark:
+				dial.createBookmark();
+				break;
+			case app.Messages.Commands.menuCreateFolder:
+				dial.createFolder();
+				break;
+			case app.Messages.Commands.menuEditSettings:
+				dial.editSettings();
+				break;
+			case app.Messages.Commands.menuEditProperties:
+				dial.editProperties(dial._selectedItem);
+				break;
+			case app.Messages.Commands.menuRefreshNode:
+				dial.refreshNode(dial._selectedItem);
+				break;
+			case app.Messages.Commands.menuCaptureHere:
+				dial.captureHere(dial._selectedItem);
+				break;
+			case app.Messages.Commands.menuCapturePage:
+				dial.capturePage(dial._selectedItem);
+				break;
+			case app.Messages.Commands.menuDeleteNode:
+				dial.deleteNode();
 				break;
 		}
 	});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
 
   "manifest_version": 2,
   "name": "Quick Dial",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "author": "MatMoul",
   "homepage_url": "https://github.com/MatMoul/quickdial-webext",
   "developer": {


### PR DESCRIPTION
Fixes #192

### Problem
The dial-page context menus call `window.dial.*` functions via `browser.tabs.executeScript`. That API was deprecated in Firefox 149 and removed in Firefox 152, so creating/editing bookmarks and folders (and the other dial-page menu actions) no longer work on current Firefox.

### Fix
Switch the menu handlers from `tabs.executeScript` to `tabs.sendMessage`, as recommended in the issue.

- Added menu command IDs (`menuCreateBookmark` … `menuDeleteNode`, 200–207) to the `Commands` enum in both `background.js` and `dial.js`.
- Replaced the 8 `executeScript({ code: "window.dial.X()" })` menu handlers in `background.js` with `browser.tabs.sendMessage(tab.id, { cmd: ... })`.
- Extended the existing `runtime.onMessage` listener in `dial.js` to dispatch these commands to the corresponding `dial.*` functions, preserving the original behavior (item actions still use the page-side `dial._selectedItem`).

No new permissions are required (`sendMessage` needs none; `tabs` was already requested).

### Testing
Loaded as a temporary add-on in Firefox 152 via `about:debugging` and verified all dial-page context-menu actions work:
- Page menu: New → Bookmark / Folder, Settings
- Item menu: Properties, Refresh, Capture Page, Delete, Settings